### PR TITLE
Prompting change to accomodate gemma models with a Google API

### DIFF
--- a/config/config.template
+++ b/config/config.template
@@ -54,10 +54,10 @@ STREAM_TIME_WEIGHT = 0.4
 
 [CONTENT]
 AUTHOR_WHITELIST_FILE = config\authorWhiteList.txt
-EXCLUDE_TAGS = actifit, appics, bible, booming, christianity, contest, cross-post, curation,
-   curatorapplication, erotic, heartchurch, islam, jesuschrist, minnowsupport, nsfw, partiko, porn,
-   pornography, promo-steem, realrobinhood, religion, splinterlands, steemmonsters, steemzzang,
-   test, thediarygame, thoth, weeklyreport, yehey, zzan
+EXCLUDE_TAGS = actifit, appics, bible, booming, blurt, christianity, contest, cross-post, curation, curatorapplication,
+   dtube, erotic, heartchurch, hive, hive-108451, hive-119463, islam, jesuschrist, hive, hbd, minnowsupport, nobots, norobots, 
+   nsfw, partiko, pizzagate, porn, pornography, promo-steem, realrobinhood, religion, splinterlands, steemhostiletakeover,
+   steemmonsters, steemzzang, test, weeklyreport, whaleshares, yehey, zzan
 INCLUDE_TAGS =
 LANGUAGE = de, en, es, fr, it, ukr
 MAX_DOWNVOTES = 5

--- a/config/systemPromptTemplate_Gemma.txt
+++ b/config/systemPromptTemplate_Gemma.txt
@@ -12,7 +12,7 @@ human written posts that deserve visibility; and filter out low-quality or inapp
 *   When recommending content, provide clear reasons for your decision that highlight the post's strengths.
 *   Adhere strictly to the task-specific instructions, exclusion conditions, and output format provided in the user prompt.
 *   Encourage authentic human voices on the blockchain while maintaining quality standards. When evaluating borderline content,
-    lean toward exclusion unless it demonstrates exceptional quality, unique insights, and clear evidence of expertise or substantial research.
+    exclude it unless it demonstrates exceptional quality, unique insights, and clear evidence of expertise or substantial research.
 
 ## GENERAL EVALUATION CRITERIA FOR HIGH-QUALITY CONTENT
 When evaluating any article, prioritize content that demonstrates:
@@ -44,6 +44,6 @@ Always be vigilant and filter out content that:
     *   **+1 Bonus:** Multiple relevant personal examples that directly illustrate key points
     *   **+1 Bonus:** Clear evidence of advanced analysis, original research, or synthesis of complex ideas.
     *   **-2 Penalty:** Relies primarily on common knowledge or basic explanations available elsewhere.
-*   **Threshold:** To be considered for curation, content should generally meet a quality score of 9 out of 10. This is an internal
+    *   **Threshold:** To be considered for curation, content should generally meet a quality score of 9 out of 10. This is an internal
     guideline to ensure high standards. The final decision to curate or not for a specific task will also depend on the EXCLUSION CONDITIONS
     in the user prompt.

--- a/src/aiCurator.py
+++ b/src/aiCurator.py
@@ -8,6 +8,7 @@ import logging
 import configparser
 from pathlib import Path
 from modelManager import ModelManager
+from promptHelper import construct_messages
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
@@ -115,16 +116,7 @@ def aicurate(arliaiKey, arliaiModel, arliaiUrl, postBody, maxTokens=8192, model_
         
         payloadDict = {
             "model": current_model,
-            "messages": [
-                {
-                    "role": "system",
-                    "content": systemPrompt
-                },
-                {
-                    "role": "user",
-                    "content": f"{curationPrompt}\n\n## ARTICLE FOR EVALUATION\n\n{postBody}"
-                }
-            ],
+            "messages": construct_messages(arliaiUrl, current_model, systemPrompt, f"{curationPrompt}\n\n## ARTICLE FOR EVALUATION\n\n{postBody}"),
             "temperature": 0.3,
             "top_p": 0.85,
             "max_tokens": maxTokens,
@@ -132,15 +124,15 @@ def aicurate(arliaiKey, arliaiModel, arliaiUrl, postBody, maxTokens=8192, model_
             stop_param_name: ["END_OF_CURATION_REPORT", "DO NOT CURATE"]
         }
 
-        if arliaiUrl.startswith("https://api.arliai.com"):  # ARLIAI API/models (vllm API)
-            payloadDict["repetition_penalty"] = 1.1
-            payloadDict["top_k"] = 40
-            payloadDict["frequency_penalty"] = 0.3
-            payloadDict["presence_penalty"] = 0.3
-            payloadDict["min_p"] = 0.0
-            payloadDict["extra_body"] = {
-                "chat_template_kwargs": {"enable_thinking": False}
-            }
+        # if arliaiUrl.startswith("https://api.arliai.com"):  # ARLIAI API/models (vllm API)
+        #     payloadDict["repetition_penalty"] = 1.1
+        #     payloadDict["top_k"] = 40
+        #     payloadDict["frequency_penalty"] = 0.3
+        #     payloadDict["presence_penalty"] = 0.3
+        #     payloadDict["min_p"] = 0.0
+        #     payloadDict["extra_body"] = {
+        #         "chat_template_kwargs": {"enable_thinking": False}
+        #     }
 
         payload = json.dumps(payloadDict)
 

--- a/src/aiIntro.py
+++ b/src/aiIntro.py
@@ -5,6 +5,7 @@ import re
 import time
 import logging
 from modelManager import ModelManager
+from promptHelper import construct_messages
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
@@ -94,17 +95,6 @@ def aiIntro(arliaiKey, arliaiModel, arliaiUrl, startTime, endTime, combinedComme
         stop_param_name = "stop_sequences"
 
     payloadDict = {
-        "model": arliaiModel,
-        "messages": [
-            {
-                "role": "system",
-                "content": systemPrompt
-            },
-            {
-                "role": "user",
-                "content": userPrompt
-            }
-        ],
         "temperature": 0.3,
         "top_p": 0.85,
         "max_tokens": maxTokens,
@@ -133,6 +123,7 @@ def aiIntro(arliaiKey, arliaiModel, arliaiUrl, startTime, endTime, combinedComme
         current_model = model_manager.current_model
         
         payloadDict["model"] = current_model
+        payloadDict["messages"] = construct_messages(arliaiUrl, current_model, systemPrompt, userPrompt)
         payload = json.dumps(payloadDict)
 
         for attempt in range(max_retries):

--- a/src/promptHelper.py
+++ b/src/promptHelper.py
@@ -1,0 +1,37 @@
+"""
+Helper module for constructing API messages.
+"""
+
+def construct_messages(arliaiUrl, model, systemPrompt, userPrompt):
+    """
+    Constructs the messages list for the API payload.
+    Merges system and user prompts if using Google API (OpenAI compatibility) with Gemma models.
+    """
+    # Check for Google API (OpenAI compatibility endpoint) and Gemma model
+    target_url_prefix = "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+    
+    is_google_openai = arliaiUrl.startswith(target_url_prefix)
+    is_gemma = "gemma" in model.lower()
+    
+    if is_google_openai and is_gemma:
+        new_content = (
+            f"**SYSTEM INSTRUCTIONS:**\n{systemPrompt}\n\n"
+            f"**USER REQUEST:**\n{userPrompt}"
+        )
+        return [
+            {
+                "role": "user",
+                "content": new_content
+            }
+        ]
+    
+    return [
+        {
+            "role": "system",
+            "content": systemPrompt
+        },
+        {
+            "role": "user",
+            "content": userPrompt
+        }
+    ]


### PR DESCRIPTION
Google throttled down the free API access to gemini models.   In order to use their API, it appears necessary to switch to Gemma or switch to a paid tier.  Paid tier is already working.  This PR will enable gemma usage through Google's API.

- Added promptHelper in order to adjust the prompt message for Gemmamodels on Google.
- No "system" context is allowed in their API, so we stuffed it into the user role.

Related issues:
- https://github.com/remlaps/Thoth/issues/55
- https://github.com/remlaps/Thoth/issues/18